### PR TITLE
respect Makefile $prefix option

### DIFF
--- a/hyprprop
+++ b/hyprprop
@@ -41,7 +41,7 @@ prop() {
 }
 
 cleanup() {
-    hyprevents -f /usr/share/hyprprop/event_handler -k
+    hyprevents -f $(dirname `dirname $0`)/share/hyprprop/event_handler -k
 }
 
 event_handler() {
@@ -58,7 +58,7 @@ terminate() {
 }
 
 # Capture events on hyprland window/workspace change events
-hyprevents -f /usr/share/hyprprop/event_handler 2>/dev/null &
+hyprevents -f $(dirname `dirname $0`)/share/hyprprop/event_handler 2>/dev/null &
 trap event_handler USR1
 
 trap terminate SIGINT


### PR DESCRIPTION
Moved from /etc to /bin to signify they're executable. Use relative paths (dirname $0) to allow for PREFIXes that are not /usr.

https://github.com/NixOS/nixpkgs/pull/278114